### PR TITLE
fix: convert AgentResult to str in Slack adapter

### DIFF
--- a/src/yui/slack_adapter.py
+++ b/src/yui/slack_adapter.py
@@ -84,7 +84,8 @@ def run_slack(config: Optional[dict] = None) -> None:
             session_manager.add_message(session_id, "user", text)
 
             # Get response
-            response = agent(text)
+            result = agent(text)
+            response = str(result)
 
             # Add assistant message
             session_manager.add_message(session_id, "assistant", response)
@@ -126,7 +127,8 @@ def run_slack(config: Optional[dict] = None) -> None:
             session_manager.add_message(session_id, "user", text)
 
             # Get response
-            response = agent(text)
+            result = agent(text)
+            response = str(result)
 
             # Add assistant message
             session_manager.add_message(session_id, "assistant", response)


### PR DESCRIPTION
## Bug Fix
`agent(text)` returns `AgentResult` (Strands SDK), not `str`. This caused:
- `sqlite3.ProgrammingError: type 'AgentResult' is not supported` when saving to session DB
- Error message posted to Slack instead of actual response

## Fix
Both `handle_mention` and `handle_dm` now do `result = agent(text); response = str(result)`

## Verified
- Live Socket Mode test — Bedrock responded, but crashed on DB save → now fixed
- 80 mock tests passing