### PR TITLE
fix: concurrent requests + shell hang + kiro logging (#11 #12 #13)

### DIFF
--- a/src/yui/tools/kiro_delegate.py
+++ b/src/yui/tools/kiro_delegate.py
@@ -39,6 +39,7 @@ def kiro_delegate(task: str, working_directory: str = ".") -> str:
         output = result.stdout + result.stderr
         # Strip ANSI codes
         clean_output = re.sub(r"\x1b\[[0-9;]*m", "", output)
+        logger.info("Kiro CLI output (%d chars): %s", len(clean_output), clean_output[:500])
         return clean_output
 
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
Closes #11 #12 #13

## Changes
1. **ConcurrencyException fix** — threading.Lock serializes agent calls; queued requests get a 'processing' message
2. **Shell confirmation hang fix** — replaced strands_tools.shell with direct subprocess.run (no interactive prompt)
3. **Kiro delegate logging** — subprocess output logged at INFO level

## Tests
82 passed, 3 skipped (+2 new tests for timeout and exit code handling)