### PR TITLE
feat: Workshop C-5/C-6/C-7 — Reporter + Resource Manager + CLI (AC-78~AC-85)

### DIFF
--- a/src/yui/config.py
+++ b/src/yui/config.py
@@ -94,6 +94,40 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "servers": [],
         "auto_connect": True,
     },
+    "workshop": {
+        "test": {
+            "region": "us-east-1",
+            "cleanup_after_test": True,
+            "timeout_per_step_seconds": 300,
+            "max_total_duration_minutes": 120,
+            "max_cost_usd": 10.0,
+            "headed": False,
+            "console_auth": {
+                "method": "iam_user",
+                "account_id": "",
+                "username": "",
+            },
+            "video": {
+                "enabled": True,
+                "resolution": {"width": 1920, "height": 1080},
+                "per_step": True,
+                "full_walkthrough": True,
+            },
+            "output_dir": "~/.yui/workshop-tests/",
+            "screenshot": {
+                "enabled": True,
+                "on_step_complete": True,
+                "on_failure": True,
+                "full_page": True,
+            },
+        },
+        "report": {
+            "format": "markdown",
+            "include_screenshots": True,
+            "include_video_links": True,
+            "slack_notify": True,
+        },
+    },
     "runtime": {
         "session": {
             "db_path": "~/.yui/sessions.db",

--- a/src/yui/workshop/__init__.py
+++ b/src/yui/workshop/__init__.py
@@ -1,4 +1,4 @@
-"""Workshop Testing — automated workshop scraping and step planning."""
+"""Workshop Testing — automated workshop scraping, planning, execution, and reporting."""
 
 from yui.workshop.models import (
     ExecutableStep,
@@ -8,12 +8,24 @@ from yui.workshop.models import (
     TestRun,
     WorkshopPage,
 )
+from yui.workshop.reporter import WorkshopReporter
+from yui.workshop.resource_manager import ResourceManager
+from yui.workshop.runner import (
+    WorkshopCostLimitError,
+    WorkshopTestRunner,
+    WorkshopTimeoutError,
+)
 
 __all__ = [
     "ExecutableStep",
+    "ResourceManager",
     "StepOutcome",
     "StepResult",
     "StepType",
     "TestRun",
+    "WorkshopCostLimitError",
     "WorkshopPage",
+    "WorkshopReporter",
+    "WorkshopTestRunner",
+    "WorkshopTimeoutError",
 ]

--- a/src/yui/workshop/reporter.py
+++ b/src/yui/workshop/reporter.py
@@ -1,0 +1,173 @@
+"""Workshop Test Reporter — structured reports and Slack notifications (AC-78, AC-79)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from yui.workshop.models import StepOutcome, StepResult, TestRun
+
+logger = logging.getLogger(__name__)
+
+_RESULT_EMOJI: dict[StepResult, str] = {
+    StepResult.PASS: "✅",
+    StepResult.FAIL: "❌",
+    StepResult.SKIP: "⏭️",
+    StepResult.TIMEOUT: "⏰",
+    StepResult.NOT_RUN: "⬜",
+}
+
+
+def _fmt_duration(seconds: float) -> str:
+    if seconds < 0:
+        seconds = 0.0
+    mins = int(seconds // 60)
+    secs = int(seconds % 60)
+    if mins > 0:
+        return f"{mins}m {secs}s"
+    return f"{secs}s"
+
+
+def _count_by_result(outcomes: list[StepOutcome]) -> dict[StepResult, int]:
+    counts: dict[StepResult, int] = {}
+    for o in outcomes:
+        counts[o.result] = counts.get(o.result, 0) + 1
+    return counts
+
+
+class WorkshopReporter:
+    def generate_report(self, test_run: TestRun) -> str:
+        lines: list[str] = []
+        date_str = test_run.start_time or datetime.now(timezone.utc).isoformat()
+        lines.append(f"# Workshop Test Report — {date_str}")
+        lines.append("")
+        lines.append(f"**Workshop:** {test_run.workshop_title}")
+        lines.append(f"**URL:** {test_run.workshop_url}")
+        lines.append(f"**Test ID:** {test_run.test_id}")
+        lines.append("")
+
+        counts = _count_by_result(test_run.outcomes)
+        total = len(test_run.outcomes)
+        passed = counts.get(StepResult.PASS, 0)
+        failed = counts.get(StepResult.FAIL, 0)
+        skipped = counts.get(StepResult.SKIP, 0)
+        timed_out = counts.get(StepResult.TIMEOUT, 0)
+        duration = _fmt_duration(test_run.total_duration_seconds)
+
+        lines.append("## Summary")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Total Steps | {total} |")
+        lines.append(f"| Passed | {passed} |")
+        lines.append(f"| Failed | {failed} |")
+        lines.append(f"| Skipped | {skipped} |")
+        lines.append(f"| Timed Out | {timed_out} |")
+        lines.append(f"| Duration | {duration} |")
+        lines.append("")
+
+        videos = [o for o in test_run.outcomes if o.video_path]
+        if videos:
+            lines.append("## Video Recordings")
+            lines.append("")
+            for o in videos:
+                lines.append(
+                    f"- **{o.step.title}** ({o.step.step_id}): "
+                    f"[{o.video_path}]({o.video_path})"
+                )
+            lines.append("")
+
+        lines.append("## Step Results")
+        lines.append("")
+        lines.append("| # | Step | Type | Result | Duration |")
+        lines.append("|---|------|------|--------|----------|")
+        for o in test_run.outcomes:
+            emoji = _RESULT_EMOJI.get(o.result, "❓")
+            lines.append(
+                f"| {o.step.step_id} "
+                f"| {o.step.title} "
+                f"| {o.step.step_type.value} "
+                f"| {emoji} {o.result.value} "
+                f"| {_fmt_duration(o.duration_seconds)} |"
+            )
+        lines.append("")
+
+        failed_outcomes = [
+            o for o in test_run.outcomes
+            if o.result in (StepResult.FAIL, StepResult.TIMEOUT)
+        ]
+        if failed_outcomes:
+            lines.append("## Failed Steps Detail")
+            lines.append("")
+            for o in failed_outcomes:
+                lines.append(f"### {o.step.step_id}: {o.step.title}")
+                lines.append("")
+                if o.error_message:
+                    lines.append(f"**Error:** {o.error_message}")
+                    lines.append("")
+                if o.screenshot_path:
+                    lines.append(f"**Screenshot:** ![screenshot]({o.screenshot_path})")
+                    lines.append("")
+                if o.actual_output:
+                    lines.append("**Actual Output:**")
+                    lines.append("```")
+                    lines.append(o.actual_output)
+                    lines.append("```")
+                    lines.append("")
+
+        lines.append("## AWS Resources Created")
+        lines.append("")
+        lines.append(
+            f"_Resource tracking managed by ResourceManager "
+            f"(tag: `yui:workshop-test={test_run.test_id}`)_"
+        )
+        lines.append("")
+        return "\n".join(lines)
+
+    def generate_slack_summary(self, test_run: TestRun) -> str:
+        counts = _count_by_result(test_run.outcomes)
+        total = len(test_run.outcomes)
+        passed = counts.get(StepResult.PASS, 0)
+        failed = counts.get(StepResult.FAIL, 0)
+        skipped = counts.get(StepResult.SKIP, 0)
+        timed_out = counts.get(StepResult.TIMEOUT, 0)
+        duration = _fmt_duration(test_run.total_duration_seconds)
+
+        if failed > 0 or timed_out > 0:
+            status = "🔴 FAIL"
+        elif total > 0 and passed == total:
+            status = "🟢 PASS"
+        else:
+            status = "🟡 PARTIAL"
+
+        parts: list[str] = [
+            f"*Workshop Test Result: {status}*",
+            f"📘 {test_run.workshop_title}",
+            f"🆔 `{test_run.test_id}`",
+            f"✅ {passed}/{total} passed | ❌ {failed} failed | ⏭️ {skipped} skipped | ⏰ {timed_out} timeout",
+            f"⏱️ {duration}",
+        ]
+
+        failed_names = [
+            o.step.title
+            for o in test_run.outcomes
+            if o.result in (StepResult.FAIL, StepResult.TIMEOUT)
+        ]
+        if failed_names:
+            parts.append("❌ Failed: " + ", ".join(failed_names[:5]))
+            if len(failed_names) > 5:
+                parts.append(f"   ...and {len(failed_names) - 5} more")
+
+        return "\n".join(parts)
+
+    def save_report(self, test_run: TestRun, output_dir: str) -> str:
+        report_content = self.generate_report(test_run)
+        out_path = Path(os.path.expanduser(output_dir))
+        out_path.mkdir(parents=True, exist_ok=True)
+        filename = f"report-{test_run.test_id}.md"
+        filepath = out_path / filename
+        filepath.write_text(report_content, encoding="utf-8")
+        logger.info("Report saved to %s", filepath)
+        return str(filepath.resolve())

--- a/src/yui/workshop/resource_manager.py
+++ b/src/yui/workshop/resource_manager.py
@@ -1,0 +1,242 @@
+"""Resource Manager — tag-based cleanup and cost guard (AC-80, AC-81).
+
+Manages AWS resources created during workshop tests by tagging them
+and providing automated cleanup. Includes a cost guard to abort tests
+that exceed a configured spending limit.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+TAG_KEY = "yui:workshop-test"
+
+_RESOURCE_DELETERS: dict[str, str] = {
+    "ec2:instance": "ec2",
+    "ec2:security-group": "ec2",
+    "ec2:vpc": "ec2",
+    "s3": "s3",
+    "lambda": "lambda",
+    "cloudformation": "cloudformation",
+    "iam:role": "iam",
+    "iam:policy": "iam",
+    "dynamodb:table": "dynamodb",
+    "sqs": "sqs",
+    "sns": "sns",
+}
+
+
+def _parse_arn_service(arn: str) -> str | None:
+    """Extract a normalised service:resource-type key from an ARN."""
+    match = re.match(r"arn:[^:]+:([^:]+):[^:]*:[^:]*:([^:/]+)", arn)
+    if not match:
+        return None
+    service = match.group(1)
+    resource_type = match.group(2)
+    if service == "ec2" and resource_type.startswith("instance"):
+        return "ec2:instance"
+    if service == "ec2" and resource_type.startswith("security-group"):
+        return "ec2:security-group"
+    if service == "ec2" and resource_type.startswith("vpc"):
+        return "ec2:vpc"
+    if service == "iam" and resource_type.startswith("role"):
+        return "iam:role"
+    if service == "iam" and resource_type.startswith("policy"):
+        return "iam:policy"
+    if service == "dynamodb" and resource_type.startswith("table"):
+        return "dynamodb:table"
+    return service
+
+
+# ---------------------------------------------------------------------------
+# ResourceManager
+# ---------------------------------------------------------------------------
+
+
+class ResourceManager:
+    """Tag-based AWS resource tracking and cleanup for workshop tests."""
+
+    TAG_KEY = TAG_KEY
+
+    def __init__(
+        self,
+        region: str = "us-east-1",
+        max_cost_usd: float = 10.0,
+        session: Any | None = None,
+    ) -> None:
+        self.region = region
+        self.max_cost_usd = max_cost_usd
+        self._session = session or boto3.Session(region_name=region)
+        self.tagging = self._session.client(
+            "resourcegroupstaggingapi", region_name=region
+        )
+
+    def tag_resource(self, resource_arn: str, test_id: str) -> None:
+        """Attach a workshop-test tag to an AWS resource."""
+        try:
+            self.tagging.tag_resources(
+                ResourceARNList=[resource_arn],
+                Tags={self.TAG_KEY: test_id},
+            )
+            logger.info("Tagged %s with %s=%s", resource_arn, self.TAG_KEY, test_id)
+        except ClientError as e:
+            logger.error("Failed to tag %s: %s", resource_arn, e)
+            raise
+
+    def find_test_resources(self, test_id: str) -> list[str]:
+        """Find all resource ARNs tagged with the given test ID."""
+        arns: list[str] = []
+        paginator = self.tagging.get_paginator("get_resources")
+        pages = paginator.paginate(
+            TagFilters=[{"Key": self.TAG_KEY, "Values": [test_id]}],
+        )
+        for page in pages:
+            for mapping in page.get("ResourceTagMappingList", []):
+                arns.append(mapping["ResourceARN"])
+        return arns
+
+    def cleanup_resources(self, test_id: str) -> dict[str, Any]:
+        """Delete all AWS resources tagged with the test ID."""
+        arns = self.find_test_resources(test_id)
+        result: dict[str, list[str]] = {
+            "deleted": [],
+            "failed": [],
+            "skipped": [],
+        }
+
+        for arn in arns:
+            svc_key = _parse_arn_service(arn)
+            if svc_key is None or svc_key not in _RESOURCE_DELETERS:
+                logger.warning("No deleter for ARN %s (service=%s), skipping", arn, svc_key)
+                result["skipped"].append(arn)
+                continue
+
+            try:
+                self._delete_resource(arn, svc_key)
+                result["deleted"].append(arn)
+                logger.info("Deleted %s", arn)
+            except ClientError as e:
+                logger.error("Failed to delete %s: %s", arn, e)
+                result["failed"].append(arn)
+
+        if result["deleted"]:
+            try:
+                self.tagging.untag_resources(
+                    ResourceARNList=result["deleted"],
+                    TagKeys=[self.TAG_KEY],
+                )
+            except ClientError:
+                logger.warning("Failed to untag deleted resources")
+
+        return result
+
+    def _delete_resource(self, arn: str, svc_key: str) -> None:
+        """Delete a single resource based on its ARN and service key."""
+        if svc_key == "ec2:instance":
+            ec2 = self._session.client("ec2", region_name=self.region)
+            instance_id = arn.rsplit("/", 1)[-1]
+            ec2.terminate_instances(InstanceIds=[instance_id])
+        elif svc_key == "s3":
+            s3 = self._session.client("s3", region_name=self.region)
+            bucket_name = arn.rsplit(":::", 1)[-1]
+            try:
+                objects = s3.list_objects_v2(Bucket=bucket_name)
+                for obj in objects.get("Contents", []):
+                    s3.delete_object(Bucket=bucket_name, Key=obj["Key"])
+            except ClientError:
+                pass
+            s3.delete_bucket(Bucket=bucket_name)
+        elif svc_key == "lambda":
+            lam = self._session.client("lambda", region_name=self.region)
+            func_name = arn.rsplit(":", 1)[-1]
+            lam.delete_function(FunctionName=func_name)
+        elif svc_key == "cloudformation":
+            cfn = self._session.client("cloudformation", region_name=self.region)
+            stack_name = arn.rsplit("/", 1)[-1].split("/")[0]
+            cfn.delete_stack(StackName=stack_name)
+        elif svc_key == "dynamodb:table":
+            ddb = self._session.client("dynamodb", region_name=self.region)
+            table_name = arn.rsplit("/", 1)[-1]
+            ddb.delete_table(TableName=table_name)
+        elif svc_key == "sqs":
+            sqs = self._session.client("sqs", region_name=self.region)
+            parts = arn.split(":")
+            queue_name = parts[-1]
+            account_id = parts[4]
+            queue_url = f"https://sqs.{self.region}.amazonaws.com/{account_id}/{queue_name}"
+            sqs.delete_queue(QueueUrl=queue_url)
+        elif svc_key == "sns":
+            sns = self._session.client("sns", region_name=self.region)
+            sns.delete_topic(TopicArn=arn)
+        elif svc_key == "ec2:security-group":
+            ec2 = self._session.client("ec2", region_name=self.region)
+            sg_id = arn.rsplit("/", 1)[-1]
+            ec2.delete_security_group(GroupId=sg_id)
+        elif svc_key == "iam:role":
+            iam = self._session.client("iam", region_name=self.region)
+            role_name = arn.rsplit("/", 1)[-1]
+            iam.delete_role(RoleName=role_name)
+        elif svc_key == "iam:policy":
+            iam = self._session.client("iam", region_name=self.region)
+            iam.delete_policy(PolicyArn=arn)
+        else:
+            raise ClientError(
+                {"Error": {"Code": "UnsupportedResource", "Message": f"No handler for {svc_key}"}},
+                "DeleteResource",
+            )
+
+    def check_cost_guard(self, test_id: str) -> bool:
+        """Check whether projected costs exceed the configured limit.
+
+        Returns True if costs are within the limit, False if limit exceeded.
+        """
+        try:
+            ce = self._session.client("ce", region_name="us-east-1")
+            end = datetime.now(timezone.utc).date()
+            start = end - timedelta(days=1)
+
+            response = ce.get_cost_and_usage(
+                TimePeriod={
+                    "Start": start.isoformat(),
+                    "End": end.isoformat(),
+                },
+                Granularity="DAILY",
+                Metrics=["UnblendedCost"],
+                Filter={
+                    "Tags": {
+                        "Key": self.TAG_KEY,
+                        "Values": [test_id],
+                    },
+                },
+            )
+
+            total_cost = 0.0
+            for period in response.get("ResultsByTime", []):
+                amount_str = period.get("Total", {}).get("UnblendedCost", {}).get("Amount", "0")
+                total_cost += float(amount_str)
+
+            logger.info(
+                "Cost guard: test_id=%s cost=%.2f limit=%.2f",
+                test_id, total_cost, self.max_cost_usd,
+            )
+
+            return total_cost <= self.max_cost_usd
+
+        except ClientError as e:
+            logger.warning("Cost Explorer query failed: %s — allowing test to continue", e)
+            return True
+        except Exception as e:
+            logger.warning("Cost guard check error: %s — allowing test to continue", e)
+            return True

--- a/src/yui/workshop/runner.py
+++ b/src/yui/workshop/runner.py
@@ -1,0 +1,272 @@
+"""Workshop Test Runner — integration orchestrator (AC-82, AC-83, AC-84, AC-85)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from yui.workshop.models import (
+    ExecutableStep,
+    StepOutcome,
+    StepResult,
+    StepType,
+    TestRun,
+)
+from yui.workshop.reporter import WorkshopReporter
+from yui.workshop.resource_manager import ResourceManager
+
+try:
+    from yui.workshop.console_auth import ConsoleAuthenticator  # type: ignore[import-not-found]
+except ImportError:
+    ConsoleAuthenticator = None  # type: ignore[assignment,misc]
+
+try:
+    from yui.workshop.executor import StepExecutor  # type: ignore[import-not-found]
+except ImportError:
+    StepExecutor = None  # type: ignore[assignment,misc]
+
+logger = logging.getLogger(__name__)
+
+
+class WorkshopTimeoutError(Exception):
+    """Raised when a step or total timeout is exceeded."""
+
+
+class WorkshopCostLimitError(Exception):
+    """Raised when the cost guard threshold is breached."""
+
+
+def _parse_step_range(spec: str, total: int) -> set[int]:
+    indices: set[int] = set()
+    for part in spec.split(","):
+        part = part.strip()
+        if "-" in part:
+            start_s, end_s = part.split("-", 1)
+            start = int(start_s.strip())
+            end = int(end_s.strip())
+            for i in range(max(1, start), min(total, end) + 1):
+                indices.add(i - 1)
+        else:
+            idx = int(part.strip()) - 1
+            if 0 <= idx < total:
+                indices.add(idx)
+    return indices
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class WorkshopTestRunner:
+    """Orchestrates full workshop test execution."""
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        self.config = config
+        ws_cfg = config.get("workshop", {}).get("test", {})
+        self.timeout_per_step = ws_cfg.get("timeout_per_step_seconds", 300)
+        self.max_total_duration = ws_cfg.get("max_total_duration_minutes", 120) * 60
+        self.max_cost_usd = ws_cfg.get("max_cost_usd", 10.0)
+        self.cleanup_after_test = ws_cfg.get("cleanup_after_test", True)
+        self.region = ws_cfg.get("region", "us-east-1")
+        self.output_dir = ws_cfg.get(
+            "output_dir",
+            config.get("workshop", {}).get("test", {}).get(
+                "video", {}
+            ).get("output_dir", "~/.yui/workshop-tests/"),
+        )
+        self.reporter = WorkshopReporter()
+        self.resource_manager = ResourceManager(
+            region=self.region,
+            max_cost_usd=self.max_cost_usd,
+        )
+
+    async def run_test(
+        self,
+        workshop_url: str,
+        options: dict[str, Any] | None = None,
+    ) -> TestRun:
+        opts = options or {}
+        dry_run: bool = opts.get("dry_run", False)
+        step_filter: str | None = opts.get("steps")
+        do_cleanup: bool = opts.get("cleanup", self.cleanup_after_test)
+
+        test_id = f"wt-{uuid.uuid4().hex[:8]}"
+        test_run = TestRun(
+            test_id=test_id,
+            workshop_url=workshop_url,
+            workshop_title="",
+            start_time=_now_iso(),
+            output_dir=str(Path(self.output_dir).expanduser()),
+        )
+
+        overall_start = time.monotonic()
+
+        try:
+            from yui.workshop.scraper import scrape_workshop
+            pages = await scrape_workshop(workshop_url)
+            if pages:
+                test_run.workshop_title = pages[0].title
+            logger.info("Scraped %d pages from %s", len(pages), workshop_url)
+
+            from yui.workshop.planner import plan_steps
+            bedrock_client = None
+            steps = await plan_steps(pages, bedrock_client)
+            test_run.steps = steps
+            logger.info("Planned %d executable steps", len(steps))
+
+            if step_filter:
+                selected = _parse_step_range(step_filter, len(steps))
+                steps = [s for i, s in enumerate(steps) if i in selected]
+                test_run.steps = steps
+                logger.info("Filtered to %d steps (spec=%s)", len(steps), step_filter)
+
+            if dry_run:
+                for step in steps:
+                    test_run.outcomes.append(
+                        StepOutcome(step=step, result=StepResult.NOT_RUN, timestamp=_now_iso())
+                    )
+                test_run.end_time = _now_iso()
+                test_run.total_duration_seconds = time.monotonic() - overall_start
+                return test_run
+
+            if StepExecutor is None:
+                logger.warning(
+                    "StepExecutor not available (C-3/C-4 not installed). "
+                    "Marking all steps as NOT_RUN."
+                )
+                for step in steps:
+                    test_run.outcomes.append(
+                        StepOutcome(step=step, result=StepResult.NOT_RUN, timestamp=_now_iso())
+                    )
+            else:
+                await self._execute_steps(test_run, steps, overall_start)
+
+        except WorkshopCostLimitError as e:
+            logger.error("Cost guard triggered: %s", e)
+        except WorkshopTimeoutError as e:
+            logger.error("Total timeout exceeded: %s", e)
+        except Exception as e:
+            logger.error("Unexpected error during test run: %s", e, exc_info=True)
+        finally:
+            test_run.end_time = _now_iso()
+            test_run.total_duration_seconds = time.monotonic() - overall_start
+
+            try:
+                report_path = self.reporter.save_report(test_run, self.output_dir)
+                logger.info("Report saved: %s", report_path)
+            except Exception as e:
+                logger.error("Failed to save report: %s", e)
+
+            if do_cleanup and not dry_run:
+                try:
+                    result = self.resource_manager.cleanup_resources(test_id)
+                    logger.info("Cleanup result: %s", result)
+                except Exception as e:
+                    logger.error("Cleanup failed: %s", e)
+
+        return test_run
+
+    async def _execute_steps(
+        self,
+        test_run: TestRun,
+        steps: list[ExecutableStep],
+        overall_start: float,
+    ) -> None:
+        for step in steps:
+            elapsed = time.monotonic() - overall_start
+            if elapsed > self.max_total_duration:
+                test_run.outcomes.append(
+                    StepOutcome(
+                        step=step,
+                        result=StepResult.TIMEOUT,
+                        error_message="Total test duration exceeded",
+                        timestamp=_now_iso(),
+                    )
+                )
+                raise WorkshopTimeoutError(
+                    f"Total timeout ({self.max_total_duration}s) exceeded after {elapsed:.0f}s"
+                )
+
+            if not self.resource_manager.check_cost_guard(test_run.test_id):
+                test_run.outcomes.append(
+                    StepOutcome(
+                        step=step,
+                        result=StepResult.FAIL,
+                        error_message=f"Cost guard: limit ${self.max_cost_usd} exceeded",
+                        timestamp=_now_iso(),
+                    )
+                )
+                raise WorkshopCostLimitError(f"Projected cost exceeds ${self.max_cost_usd}")
+
+            step_timeout = step.timeout_seconds or self.timeout_per_step
+            step_start = time.monotonic()
+
+            try:
+                outcome = await asyncio.wait_for(
+                    self._execute_single_step(step, test_run.test_id),
+                    timeout=step_timeout,
+                )
+                outcome.duration_seconds = time.monotonic() - step_start
+                outcome.timestamp = _now_iso()
+                test_run.outcomes.append(outcome)
+            except asyncio.TimeoutError:
+                test_run.outcomes.append(
+                    StepOutcome(
+                        step=step,
+                        result=StepResult.TIMEOUT,
+                        error_message=f"Step timeout ({step_timeout}s) exceeded",
+                        duration_seconds=time.monotonic() - step_start,
+                        timestamp=_now_iso(),
+                    )
+                )
+
+    async def _execute_single_step(
+        self,
+        step: ExecutableStep,
+        test_id: str,
+    ) -> StepOutcome:
+        if step.step_type == StepType.CLI_COMMAND and StepExecutor is None:
+            return StepOutcome(
+                step=step,
+                result=StepResult.SKIP,
+                error_message="CLI fallback: executor not available",
+            )
+
+        if StepExecutor is not None:
+            executor = StepExecutor()
+            return await executor.execute(step)
+
+        return StepOutcome(
+            step=step,
+            result=StepResult.NOT_RUN,
+            error_message="Executor not available",
+        )
+
+    def list_tests(self) -> list[dict[str, Any]]:
+        out_dir = Path(self.output_dir).expanduser()
+        if not out_dir.exists():
+            return []
+
+        tests: list[dict[str, Any]] = []
+        for report_file in sorted(out_dir.glob("report-*.md"), reverse=True):
+            test_id = report_file.stem.replace("report-", "")
+            stat = report_file.stat()
+            tests.append({
+                "test_id": test_id,
+                "file": str(report_file),
+                "size": stat.st_size,
+                "modified": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+            })
+        return tests
+
+    def show_report(self, test_id: str) -> str | None:
+        out_dir = Path(self.output_dir).expanduser()
+        report_path = out_dir / f"report-{test_id}.md"
+        if report_path.exists():
+            return report_path.read_text(encoding="utf-8")
+        return None

--- a/tests/test_workshop_cli.py
+++ b/tests/test_workshop_cli.py
@@ -1,0 +1,149 @@
+"""Tests for yui.cli workshop subcommands (AC-82, AC-85)."""
+from __future__ import annotations
+import sys
+from io import StringIO
+from unittest.mock import MagicMock, patch
+import pytest
+from yui.workshop.models import TestRun
+
+
+def _make_test_run():
+    return TestRun(test_id="wt-abc12345", workshop_url="https://catalog.workshops.aws/example",
+                   workshop_title="Example Workshop", outcomes=[],
+                   start_time="2026-02-26T10:00:00+00:00", end_time="2026-02-26T10:02:00+00:00",
+                   total_duration_seconds=120.0)
+
+
+def _run_cli(args):
+    from yui.cli import main
+    old_argv, old_stdout, old_stderr = sys.argv, sys.stdout, sys.stderr
+    sys.argv = ["yui"] + args
+    stdout_buf, stderr_buf = StringIO(), StringIO()
+    sys.stdout, sys.stderr = stdout_buf, stderr_buf
+    exit_code = 0
+    try:
+        main()
+    except SystemExit as e:
+        exit_code = e.code if isinstance(e.code, int) else 1
+    finally:
+        sys.argv, sys.stdout, sys.stderr = old_argv, old_stdout, old_stderr
+    return exit_code, stdout_buf.getvalue(), stderr_buf.getvalue()
+
+
+class TestWorkshopTestCommand:
+    @patch("yui.config.load_config")
+    @patch("yui.workshop.runner.WorkshopTestRunner")
+    def test_test_command_basic(self, mock_runner_cls, mock_load_config):
+        mock_load_config.return_value = {"workshop": {"test": {"output_dir": "/tmp"}}}
+        mock_runner = MagicMock()
+        mock_runner_cls.return_value = mock_runner
+        test_run = _make_test_run()
+        with patch("asyncio.run", side_effect=lambda coro: test_run):
+            code, out, err = _run_cli(["workshop", "test", "https://catalog.workshops.aws/example"])
+        assert code == 0
+        assert "Starting workshop test" in out
+
+    @patch("yui.config.load_config")
+    @patch("yui.workshop.runner.WorkshopTestRunner")
+    def test_dry_run_flag(self, mock_runner_cls, mock_load_config):
+        mock_load_config.return_value = {"workshop": {"test": {"output_dir": "/tmp"}}}
+        mock_runner = MagicMock()
+        mock_runner_cls.return_value = mock_runner
+        test_run = _make_test_run()
+        with patch("asyncio.run", return_value=test_run):
+            code, out, err = _run_cli(["workshop", "test", "https://catalog.workshops.aws/example", "--dry-run"])
+        assert code == 0
+        assert "Dry-run" in out
+
+    @patch("yui.config.load_config")
+    @patch("yui.workshop.runner.WorkshopTestRunner")
+    def test_cron_flag(self, mock_runner_cls, mock_load_config):
+        mock_load_config.return_value = {"workshop": {"test": {"output_dir": "/tmp"}}}
+        mock_runner = MagicMock()
+        mock_runner_cls.return_value = mock_runner
+        test_run = _make_test_run()
+        with patch("asyncio.run", return_value=test_run):
+            code, out, err = _run_cli(["workshop", "test", "https://catalog.workshops.aws/example", "--cron"])
+        assert code == 0
+        assert "Regression mode" in out
+
+    @patch("yui.config.load_config")
+    @patch("yui.workshop.runner.WorkshopTestRunner")
+    def test_steps_flag(self, mock_runner_cls, mock_load_config):
+        mock_load_config.return_value = {"workshop": {"test": {"output_dir": "/tmp"}}}
+        mock_runner = MagicMock()
+        mock_runner_cls.return_value = mock_runner
+        test_run = _make_test_run()
+        with patch("asyncio.run", return_value=test_run):
+            code, out, err = _run_cli(["workshop", "test", "https://catalog.workshops.aws/example", "--steps", "1-3"])
+        assert code == 0
+
+    @patch("yui.config.load_config")
+    @patch("yui.workshop.runner.WorkshopTestRunner")
+    def test_record_flag(self, mock_runner_cls, mock_load_config):
+        mock_load_config.return_value = {"workshop": {"test": {"output_dir": "/tmp"}}}
+        mock_runner = MagicMock()
+        mock_runner_cls.return_value = mock_runner
+        test_run = _make_test_run()
+        with patch("asyncio.run", return_value=test_run):
+            code, out, err = _run_cli(["workshop", "test", "https://catalog.workshops.aws/example", "--record"])
+        assert code == 0
+
+
+class TestWorkshopListTests:
+    @patch("yui.config.load_config")
+    @patch("yui.workshop.runner.WorkshopTestRunner")
+    def test_list_tests_empty(self, mock_runner_cls, mock_load_config):
+        mock_load_config.return_value = {"workshop": {"test": {"output_dir": "/tmp"}}}
+        mock_runner = MagicMock()
+        mock_runner_cls.return_value = mock_runner
+        mock_runner.list_tests.return_value = []
+        code, out, err = _run_cli(["workshop", "list-tests"])
+        assert code == 0
+        assert "No test runs found" in out
+
+    @patch("yui.config.load_config")
+    @patch("yui.workshop.runner.WorkshopTestRunner")
+    def test_list_tests_with_results(self, mock_runner_cls, mock_load_config):
+        mock_load_config.return_value = {"workshop": {"test": {"output_dir": "/tmp"}}}
+        mock_runner = MagicMock()
+        mock_runner_cls.return_value = mock_runner
+        mock_runner.list_tests.return_value = [
+            {"test_id": "wt-abc123", "modified": "2026-02-26T10:00:00", "size": 1234, "file": "/tmp/r.md"},
+        ]
+        code, out, err = _run_cli(["workshop", "list-tests"])
+        assert code == 0
+        assert "wt-abc123" in out
+
+
+class TestWorkshopShowReport:
+    @patch("yui.config.load_config")
+    @patch("yui.workshop.runner.WorkshopTestRunner")
+    def test_show_report_found(self, mock_runner_cls, mock_load_config):
+        mock_load_config.return_value = {"workshop": {"test": {"output_dir": "/tmp"}}}
+        mock_runner = MagicMock()
+        mock_runner_cls.return_value = mock_runner
+        mock_runner.show_report.return_value = "# Test Report Content"
+        code, out, err = _run_cli(["workshop", "show-report", "wt-abc123"])
+        assert code == 0
+        assert "# Test Report Content" in out
+
+    @patch("yui.config.load_config")
+    @patch("yui.workshop.runner.WorkshopTestRunner")
+    def test_show_report_not_found(self, mock_runner_cls, mock_load_config):
+        mock_load_config.return_value = {"workshop": {"test": {"output_dir": "/tmp"}}}
+        mock_runner = MagicMock()
+        mock_runner_cls.return_value = mock_runner
+        mock_runner.show_report.return_value = None
+        code, out, err = _run_cli(["workshop", "show-report", "wt-nonexistent"])
+        assert code == 1
+        assert "Report not found" in err
+
+
+class TestWorkshopNoAction:
+    @patch("yui.config.load_config")
+    def test_no_workshop_action(self, mock_load_config):
+        mock_load_config.return_value = {"workshop": {"test": {"output_dir": "/tmp"}}}
+        code, out, err = _run_cli(["workshop"])
+        assert code == 1
+        assert "Usage" in err

--- a/tests/test_workshop_reporter.py
+++ b/tests/test_workshop_reporter.py
@@ -1,0 +1,251 @@
+"""Tests for yui.workshop.reporter (AC-78, AC-79)."""
+from __future__ import annotations
+import os
+from pathlib import Path
+import pytest
+from yui.workshop.models import (
+    ExecutableStep, StepOutcome, StepResult, StepType, TestRun,
+)
+from yui.workshop.reporter import WorkshopReporter, _count_by_result, _fmt_duration
+
+
+def _make_step(step_id="1.0.1", title="Navigate to S3", step_type=StepType.CONSOLE_NAVIGATE,
+               description="Open the S3 console", action=None, expected_result="S3 console opens",
+               timeout_seconds=300):
+    return ExecutableStep(step_id=step_id, title=title, step_type=step_type, description=description,
+                          action=action or {}, expected_result=expected_result, timeout_seconds=timeout_seconds)
+
+
+def _make_outcome(step=None, result=StepResult.PASS, actual_output="", screenshot_path=None,
+                  video_path=None, error_message="", duration_seconds=5.0,
+                  timestamp="2026-02-26T10:00:00+00:00"):
+    return StepOutcome(step=step or _make_step(), result=result, actual_output=actual_output,
+                       screenshot_path=screenshot_path, video_path=video_path,
+                       error_message=error_message, duration_seconds=duration_seconds, timestamp=timestamp)
+
+
+def _make_test_run(test_id="wt-abc12345", outcomes=None, total_duration_seconds=120.0):
+    return TestRun(test_id=test_id, workshop_url="https://catalog.workshops.aws/example",
+                   workshop_title="Example Workshop", outcomes=outcomes or [],
+                   start_time="2026-02-26T10:00:00+00:00", end_time="2026-02-26T10:02:00+00:00",
+                   total_duration_seconds=total_duration_seconds, output_dir="/tmp/test-reports")
+
+
+class TestFmtDuration:
+    def test_seconds_only(self):
+        assert _fmt_duration(45) == "45s"
+
+    def test_minutes_and_seconds(self):
+        assert _fmt_duration(150) == "2m 30s"
+
+    def test_zero(self):
+        assert _fmt_duration(0) == "0s"
+
+    def test_negative_clamped(self):
+        assert _fmt_duration(-5) == "0s"
+
+
+class TestCountByResult:
+    def test_empty(self):
+        assert _count_by_result([]) == {}
+
+    def test_mixed(self):
+        outcomes = [
+            _make_outcome(result=StepResult.PASS), _make_outcome(result=StepResult.PASS),
+            _make_outcome(result=StepResult.FAIL), _make_outcome(result=StepResult.SKIP),
+        ]
+        counts = _count_by_result(outcomes)
+        assert counts[StepResult.PASS] == 2
+        assert counts[StepResult.FAIL] == 1
+        assert counts[StepResult.SKIP] == 1
+
+
+class TestGenerateReport:
+    def test_all_pass(self):
+        steps = [_make_step(step_id=f"1.0.{i}", title=f"Step {i}") for i in range(3)]
+        outcomes = [_make_outcome(step=s, result=StepResult.PASS) for s in steps]
+        run = _make_test_run(outcomes=outcomes)
+        reporter = WorkshopReporter()
+        md = reporter.generate_report(run)
+        assert "# Workshop Test Report" in md
+        assert "Example Workshop" in md
+        assert "wt-abc12345" in md
+        assert "| Passed | 3 |" in md
+        assert "| Failed | 0 |" in md
+        assert "## Failed Steps Detail" not in md
+
+    def test_all_fail(self):
+        step = _make_step(step_id="1.0.1", title="Create Bucket")
+        outcome = _make_outcome(step=step, result=StepResult.FAIL,
+                                error_message="Access denied", screenshot_path="/tmp/screenshot.png")
+        run = _make_test_run(outcomes=[outcome])
+        reporter = WorkshopReporter()
+        md = reporter.generate_report(run)
+        assert "| Failed | 1 |" in md
+        assert "## Failed Steps Detail" in md
+        assert "Access denied" in md
+        assert "screenshot.png" in md
+
+    def test_mixed_results(self):
+        steps = [_make_step(step_id="1.0.1", title="Setup"),
+                 _make_step(step_id="1.0.2", title="Deploy"),
+                 _make_step(step_id="1.0.3", title="Verify")]
+        outcomes = [_make_outcome(step=steps[0], result=StepResult.PASS),
+                    _make_outcome(step=steps[1], result=StepResult.FAIL, error_message="Deploy failed"),
+                    _make_outcome(step=steps[2], result=StepResult.SKIP)]
+        run = _make_test_run(outcomes=outcomes)
+        reporter = WorkshopReporter()
+        md = reporter.generate_report(run)
+        assert "| Passed | 1 |" in md
+        assert "| Failed | 1 |" in md
+        assert "| Skipped | 1 |" in md
+
+    def test_empty_test_run(self):
+        run = _make_test_run(outcomes=[])
+        reporter = WorkshopReporter()
+        md = reporter.generate_report(run)
+        assert "# Workshop Test Report" in md
+        assert "| Total Steps | 0 |" in md
+        assert "## Step Results" in md
+
+    def test_video_links_included(self):
+        step = _make_step(step_id="1.0.1", title="Video Step")
+        outcome = _make_outcome(step=step, result=StepResult.PASS, video_path="/tmp/videos/step1.mp4")
+        run = _make_test_run(outcomes=[outcome])
+        reporter = WorkshopReporter()
+        md = reporter.generate_report(run)
+        assert "## Video Recordings" in md
+        assert "/tmp/videos/step1.mp4" in md
+
+    def test_no_video_section_when_no_videos(self):
+        step = _make_step()
+        outcome = _make_outcome(step=step, result=StepResult.PASS)
+        run = _make_test_run(outcomes=[outcome])
+        reporter = WorkshopReporter()
+        md = reporter.generate_report(run)
+        assert "## Video Recordings" not in md
+
+    def test_screenshot_in_failed_detail(self):
+        step = _make_step(step_id="2.0.1", title="Failing Step")
+        outcome = _make_outcome(step=step, result=StepResult.FAIL,
+                                screenshot_path="/tmp/fail.png", error_message="Element not found")
+        run = _make_test_run(outcomes=[outcome])
+        reporter = WorkshopReporter()
+        md = reporter.generate_report(run)
+        assert "![screenshot](/tmp/fail.png)" in md
+        assert "Element not found" in md
+
+    def test_timeout_shown_in_failed_detail(self):
+        step = _make_step(step_id="3.0.1", title="Slow Step")
+        outcome = _make_outcome(step=step, result=StepResult.TIMEOUT, error_message="Step timeout exceeded")
+        run = _make_test_run(outcomes=[outcome])
+        reporter = WorkshopReporter()
+        md = reporter.generate_report(run)
+        assert "## Failed Steps Detail" in md
+        assert "Slow Step" in md
+        assert "Step timeout exceeded" in md
+
+    def test_actual_output_in_failed_detail(self):
+        step = _make_step(step_id="4.0.1", title="CLI Step")
+        outcome = _make_outcome(step=step, result=StepResult.FAIL,
+                                actual_output="Error: permission denied", error_message="Command failed")
+        run = _make_test_run(outcomes=[outcome])
+        reporter = WorkshopReporter()
+        md = reporter.generate_report(run)
+        assert "**Actual Output:**" in md
+        assert "Error: permission denied" in md
+
+    def test_aws_resources_section_present(self):
+        run = _make_test_run(outcomes=[])
+        reporter = WorkshopReporter()
+        md = reporter.generate_report(run)
+        assert "## AWS Resources Created" in md
+        assert "yui:workshop-test=wt-abc12345" in md
+
+    def test_step_results_table_columns(self):
+        step = _make_step(step_id="1.0.1", title="Test Step", step_type=StepType.CLI_COMMAND)
+        outcome = _make_outcome(step=step, result=StepResult.PASS, duration_seconds=10.0)
+        run = _make_test_run(outcomes=[outcome])
+        reporter = WorkshopReporter()
+        md = reporter.generate_report(run)
+        assert "| # | Step | Type | Result | Duration |" in md
+        assert "cli_command" in md
+
+
+class TestGenerateSlackSummary:
+    def test_all_pass(self):
+        steps = [_make_step(step_id=f"1.0.{i}") for i in range(3)]
+        outcomes = [_make_outcome(step=s, result=StepResult.PASS) for s in steps]
+        run = _make_test_run(outcomes=outcomes)
+        reporter = WorkshopReporter()
+        summary = reporter.generate_slack_summary(run)
+        assert "🟢 PASS" in summary
+        assert "3/3 passed" in summary
+        assert "wt-abc12345" in summary
+
+    def test_has_failures(self):
+        step = _make_step(step_id="1.0.1", title="Broken Step")
+        outcome = _make_outcome(step=step, result=StepResult.FAIL)
+        run = _make_test_run(outcomes=[outcome])
+        reporter = WorkshopReporter()
+        summary = reporter.generate_slack_summary(run)
+        assert "🔴 FAIL" in summary
+        assert "❌ Failed: Broken Step" in summary
+
+    def test_partial_pass(self):
+        outcomes = [_make_outcome(step=_make_step(step_id="1"), result=StepResult.PASS),
+                    _make_outcome(step=_make_step(step_id="2"), result=StepResult.SKIP)]
+        run = _make_test_run(outcomes=outcomes)
+        reporter = WorkshopReporter()
+        summary = reporter.generate_slack_summary(run)
+        assert "🟡 PARTIAL" in summary
+
+    def test_empty_run(self):
+        run = _make_test_run(outcomes=[])
+        reporter = WorkshopReporter()
+        summary = reporter.generate_slack_summary(run)
+        assert "0/0 passed" in summary
+        assert "wt-abc12345" in summary
+
+    def test_timeout_counts_as_fail(self):
+        step = _make_step(step_id="1.0.1", title="Timeout Step")
+        outcome = _make_outcome(step=step, result=StepResult.TIMEOUT)
+        run = _make_test_run(outcomes=[outcome])
+        reporter = WorkshopReporter()
+        summary = reporter.generate_slack_summary(run)
+        assert "🔴 FAIL" in summary
+        assert "Timeout Step" in summary
+
+    def test_many_failures_truncated(self):
+        outcomes = [_make_outcome(step=_make_step(step_id=f"1.0.{i}", title=f"Step {i}"),
+                                  result=StepResult.FAIL) for i in range(8)]
+        run = _make_test_run(outcomes=outcomes)
+        reporter = WorkshopReporter()
+        summary = reporter.generate_slack_summary(run)
+        assert "...and 3 more" in summary
+
+
+class TestSaveReport:
+    def test_saves_to_file(self, tmp_path):
+        run = _make_test_run(outcomes=[])
+        reporter = WorkshopReporter()
+        path = reporter.save_report(run, str(tmp_path))
+        assert os.path.exists(path)
+        assert path.endswith("report-wt-abc12345.md")
+        content = Path(path).read_text()
+        assert "# Workshop Test Report" in content
+
+    def test_creates_directory(self, tmp_path):
+        new_dir = tmp_path / "subdir" / "reports"
+        run = _make_test_run(outcomes=[])
+        reporter = WorkshopReporter()
+        path = reporter.save_report(run, str(new_dir))
+        assert os.path.exists(path)
+        assert new_dir.exists()
+
+    def test_overwrites_existing(self, tmp_path):
+        run = _make_test_run(outcomes=[])
+        reporter = WorkshopReporter()
+        path1 = reporter.save_report(run, str(tmp_path))
+        path2 = reporter.save_report(run, str(tmp_path))
+        assert path1 == path2

--- a/tests/test_workshop_resource_manager.py
+++ b/tests/test_workshop_resource_manager.py
@@ -1,0 +1,211 @@
+"""Tests for yui.workshop.resource_manager (AC-80, AC-81)."""
+from __future__ import annotations
+from unittest.mock import MagicMock
+import pytest
+from botocore.exceptions import ClientError
+from yui.workshop.resource_manager import ResourceManager, TAG_KEY, _parse_arn_service
+
+
+def _client_error(code="AccessDenied", message="Denied"):
+    return ClientError({"Error": {"Code": code, "Message": message}}, "TestOp")
+
+
+def _make_manager(max_cost_usd=10.0, tag_client=None, ce_cost=None):
+    session = MagicMock()
+    mock_tagging = tag_client or MagicMock()
+    mock_paginator = MagicMock()
+    mock_paginator.paginate.return_value = []
+    mock_tagging.get_paginator.return_value = mock_paginator
+    mock_ce = MagicMock()
+    if ce_cost is not None:
+        mock_ce.get_cost_and_usage.return_value = {
+            "ResultsByTime": [{"Total": {"UnblendedCost": {"Amount": str(ce_cost), "Unit": "USD"}}}]
+        }
+    else:
+        mock_ce.get_cost_and_usage.return_value = {"ResultsByTime": []}
+    def _client_factory(service, region_name=None):
+        if service == "resourcegroupstaggingapi":
+            return mock_tagging
+        if service == "ce":
+            return mock_ce
+        return MagicMock()
+    session.client.side_effect = _client_factory
+    mgr = ResourceManager(region="us-east-1", max_cost_usd=max_cost_usd, session=session)
+    return mgr, session
+
+
+class TestParseArnService:
+    def test_ec2_instance(self):
+        assert _parse_arn_service("arn:aws:ec2:us-east-1:123:instance/i-abc") == "ec2:instance"
+
+    def test_s3_bucket(self):
+        result = _parse_arn_service("arn:aws:s3:::my-bucket")
+        assert result is None or result == "s3"
+
+    def test_lambda_function(self):
+        assert _parse_arn_service("arn:aws:lambda:us-east-1:123:function:my-fn") == "lambda"
+
+    def test_iam_role(self):
+        assert _parse_arn_service("arn:aws:iam::123:role/my-role") == "iam:role"
+
+    def test_dynamodb_table(self):
+        assert _parse_arn_service("arn:aws:dynamodb:us-east-1:123:table/my-table") == "dynamodb:table"
+
+    def test_invalid_arn(self):
+        assert _parse_arn_service("not-an-arn") is None
+
+    def test_ec2_security_group(self):
+        assert _parse_arn_service("arn:aws:ec2:us-east-1:123:security-group/sg-abc") == "ec2:security-group"
+
+
+class TestTagResource:
+    def test_tag_success(self):
+        mgr, session = _make_manager()
+        mgr.tag_resource("arn:aws:ec2:us-east-1:123:instance/i-abc", "wt-test1")
+        mgr.tagging.tag_resources.assert_called_once_with(
+            ResourceARNList=["arn:aws:ec2:us-east-1:123:instance/i-abc"],
+            Tags={TAG_KEY: "wt-test1"},
+        )
+
+    def test_tag_client_error_propagates(self):
+        mgr, _ = _make_manager()
+        mgr.tagging.tag_resources.side_effect = _client_error()
+        with pytest.raises(ClientError):
+            mgr.tag_resource("arn:aws:ec2:us-east-1:123:instance/i-abc", "wt-test1")
+
+
+class TestFindTestResources:
+    def test_find_returns_arns(self):
+        mgr, _ = _make_manager()
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {"ResourceTagMappingList": [
+                {"ResourceARN": "arn:aws:ec2:us-east-1:123:instance/i-1"},
+                {"ResourceARN": "arn:aws:ec2:us-east-1:123:instance/i-2"},
+            ]}
+        ]
+        mgr.tagging.get_paginator.return_value = mock_paginator
+        arns = mgr.find_test_resources("wt-test1")
+        assert arns == [
+            "arn:aws:ec2:us-east-1:123:instance/i-1",
+            "arn:aws:ec2:us-east-1:123:instance/i-2",
+        ]
+
+    def test_find_empty(self):
+        mgr, _ = _make_manager()
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [{"ResourceTagMappingList": []}]
+        mgr.tagging.get_paginator.return_value = mock_paginator
+        arns = mgr.find_test_resources("wt-nonexistent")
+        assert arns == []
+
+    def test_find_multiple_pages(self):
+        mgr, _ = _make_manager()
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {"ResourceTagMappingList": [{"ResourceARN": "arn:aws:ec2:us-east-1:123:instance/i-1"}]},
+            {"ResourceTagMappingList": [{"ResourceARN": "arn:aws:ec2:us-east-1:123:instance/i-2"}]},
+        ]
+        mgr.tagging.get_paginator.return_value = mock_paginator
+        arns = mgr.find_test_resources("wt-test1")
+        assert len(arns) == 2
+
+
+class TestCleanupResources:
+    def test_cleanup_ec2_instances(self):
+        mgr, session = _make_manager()
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {"ResourceTagMappingList": [
+                {"ResourceARN": "arn:aws:ec2:us-east-1:123:instance/i-abc123"},
+            ]}
+        ]
+        mgr.tagging.get_paginator.return_value = mock_paginator
+        result = mgr.cleanup_resources("wt-test1")
+        assert "arn:aws:ec2:us-east-1:123:instance/i-abc123" in result["deleted"]
+        assert len(result["failed"]) == 0
+
+    def test_cleanup_skips_unknown_resource(self):
+        mgr, _ = _make_manager()
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {"ResourceTagMappingList": [
+                {"ResourceARN": "arn:aws:unknown:us-east-1:123:widget/w-1"},
+            ]}
+        ]
+        mgr.tagging.get_paginator.return_value = mock_paginator
+        result = mgr.cleanup_resources("wt-test1")
+        assert "arn:aws:unknown:us-east-1:123:widget/w-1" in result["skipped"]
+
+    def test_cleanup_handles_delete_error(self):
+        mgr, session = _make_manager()
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {"ResourceTagMappingList": [
+                {"ResourceARN": "arn:aws:ec2:us-east-1:123:instance/i-fail"},
+            ]}
+        ]
+        mgr.tagging.get_paginator.return_value = mock_paginator
+        mock_ec2 = MagicMock()
+        mock_ec2.terminate_instances.side_effect = _client_error("InstanceNotFound")
+        original_client = session.client.side_effect
+        def _client_with_ec2_error(service, region_name=None):
+            if service == "ec2":
+                return mock_ec2
+            return original_client(service, region_name=region_name)
+        session.client.side_effect = _client_with_ec2_error
+        result = mgr.cleanup_resources("wt-test1")
+        assert "arn:aws:ec2:us-east-1:123:instance/i-fail" in result["failed"]
+
+    def test_cleanup_no_resources(self):
+        mgr, _ = _make_manager()
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [{"ResourceTagMappingList": []}]
+        mgr.tagging.get_paginator.return_value = mock_paginator
+        result = mgr.cleanup_resources("wt-test1")
+        assert result == {"deleted": [], "failed": [], "skipped": []}
+
+    def test_cleanup_untags_deleted(self):
+        mgr, session = _make_manager()
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {"ResourceTagMappingList": [
+                {"ResourceARN": "arn:aws:lambda:us-east-1:123:function:my-fn"},
+            ]}
+        ]
+        mgr.tagging.get_paginator.return_value = mock_paginator
+        result = mgr.cleanup_resources("wt-test1")
+        assert len(result["deleted"]) == 1
+        mgr.tagging.untag_resources.assert_called_once_with(
+            ResourceARNList=result["deleted"], TagKeys=[TAG_KEY],
+        )
+
+
+class TestCheckCostGuard:
+    def test_within_limit(self):
+        mgr, _ = _make_manager(max_cost_usd=10.0, ce_cost=5.0)
+        assert mgr.check_cost_guard("wt-test1") is True
+
+    def test_exceeds_limit(self):
+        mgr, _ = _make_manager(max_cost_usd=10.0, ce_cost=15.0)
+        assert mgr.check_cost_guard("wt-test1") is False
+
+    def test_exactly_at_limit(self):
+        mgr, _ = _make_manager(max_cost_usd=10.0, ce_cost=10.0)
+        assert mgr.check_cost_guard("wt-test1") is True
+
+    def test_ce_error_allows_continuation(self):
+        mgr, session = _make_manager()
+        mock_ce = MagicMock()
+        mock_ce.get_cost_and_usage.side_effect = _client_error("DataUnavailable")
+        def _client_factory(service, region_name=None):
+            if service == "ce":
+                return mock_ce
+            return MagicMock()
+        session.client.side_effect = _client_factory
+        mgr._session = session
+        assert mgr.check_cost_guard("wt-test1") is True
+
+    def test_zero_cost(self):
+        mgr, _ = _make_manager(max_cost_usd=10.0, ce_cost=0.0)
+        assert mgr.check_cost_guard("wt-test1") is True

--- a/tests/test_workshop_runner.py
+++ b/tests/test_workshop_runner.py
@@ -1,0 +1,222 @@
+"""Tests for yui.workshop.runner (AC-82, AC-83, AC-84, AC-85)."""
+from __future__ import annotations
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+from yui.workshop.models import (
+    ExecutableStep, StepOutcome, StepResult, StepType, TestRun, WorkshopPage,
+)
+from yui.workshop.runner import (
+    WorkshopCostLimitError, WorkshopTestRunner, WorkshopTimeoutError, _parse_step_range,
+)
+
+
+def _make_config(**overrides):
+    cfg = {
+        "workshop": {
+            "test": {
+                "region": "us-east-1", "cleanup_after_test": False,
+                "timeout_per_step_seconds": 300, "max_total_duration_minutes": 120,
+                "max_cost_usd": 10.0, "output_dir": "/tmp/yui-test-reports",
+                "video": {"output_dir": "/tmp/yui-test-reports"},
+            },
+            "report": {"format": "markdown", "slack_notify": False},
+        },
+    }
+    for k, v in overrides.items():
+        cfg["workshop"]["test"][k] = v
+    return cfg
+
+
+def _make_step(step_id="1.0.1", title="Test Step", step_type=StepType.CONSOLE_NAVIGATE,
+               timeout_seconds=300):
+    return ExecutableStep(step_id=step_id, title=title, step_type=step_type,
+                          description="Test step", action={}, expected_result="Success",
+                          timeout_seconds=timeout_seconds)
+
+
+def _make_pages():
+    return [WorkshopPage(title="Example Workshop", url="https://catalog.workshops.aws/example",
+                         content="Setup instructions", module_index=1, step_index=0)]
+
+
+class TestParseStepRange:
+    def test_single_step(self):
+        assert _parse_step_range("3", 5) == {2}
+
+    def test_range(self):
+        assert _parse_step_range("1-3", 5) == {0, 1, 2}
+
+    def test_comma_list(self):
+        assert _parse_step_range("1,3,5", 5) == {0, 2, 4}
+
+    def test_mixed(self):
+        assert _parse_step_range("1-2,4", 5) == {0, 1, 3}
+
+    def test_out_of_range_ignored(self):
+        assert _parse_step_range("10", 5) == set()
+
+    def test_full_range(self):
+        assert _parse_step_range("1-5", 5) == {0, 1, 2, 3, 4}
+
+
+class TestDryRun:
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_not_run(self, tmp_path):
+        steps = [_make_step(step_id=f"1.0.{i}") for i in range(3)]
+        pages = _make_pages()
+        with (
+            patch("yui.workshop.scraper.scrape_workshop", new_callable=AsyncMock, return_value=pages),
+            patch("yui.workshop.planner.plan_steps", new_callable=AsyncMock, return_value=steps),
+        ):
+            config = _make_config(output_dir=str(tmp_path))
+            runner = WorkshopTestRunner(config)
+            result = await runner.run_test("https://catalog.workshops.aws/example", {"dry_run": True})
+        assert len(result.outcomes) == 3
+        assert all(o.result == StepResult.NOT_RUN for o in result.outcomes)
+        assert result.test_id.startswith("wt-")
+
+    @pytest.mark.asyncio
+    async def test_dry_run_with_step_filter(self, tmp_path):
+        steps = [_make_step(step_id=f"1.0.{i}") for i in range(5)]
+        pages = _make_pages()
+        with (
+            patch("yui.workshop.scraper.scrape_workshop", new_callable=AsyncMock, return_value=pages),
+            patch("yui.workshop.planner.plan_steps", new_callable=AsyncMock, return_value=steps),
+        ):
+            config = _make_config(output_dir=str(tmp_path))
+            runner = WorkshopTestRunner(config)
+            result = await runner.run_test("https://catalog.workshops.aws/example",
+                                           {"dry_run": True, "steps": "1-3"})
+        assert len(result.outcomes) == 3
+
+
+class TestExecutionWithoutExecutor:
+    @pytest.mark.asyncio
+    async def test_marks_steps_not_run(self, tmp_path):
+        steps = [_make_step()]
+        pages = _make_pages()
+        with (
+            patch("yui.workshop.scraper.scrape_workshop", new_callable=AsyncMock, return_value=pages),
+            patch("yui.workshop.planner.plan_steps", new_callable=AsyncMock, return_value=steps),
+            patch("yui.workshop.runner.StepExecutor", None),
+        ):
+            config = _make_config(output_dir=str(tmp_path))
+            runner = WorkshopTestRunner(config)
+            result = await runner.run_test("https://catalog.workshops.aws/example")
+        assert len(result.outcomes) == 1
+        assert result.outcomes[0].result == StepResult.NOT_RUN
+
+
+class TestTotalTimeout:
+    @pytest.mark.asyncio
+    async def test_total_timeout_aborts(self, tmp_path):
+        steps = [_make_step(step_id=f"1.0.{i}") for i in range(3)]
+        pages = _make_pages()
+        mock_executor_cls = MagicMock()
+        mock_executor = MagicMock()
+        async def slow_execute(step):
+            return StepOutcome(step=step, result=StepResult.PASS)
+        mock_executor.execute = slow_execute
+        mock_executor_cls.return_value = mock_executor
+        with (
+            patch("yui.workshop.scraper.scrape_workshop", new_callable=AsyncMock, return_value=pages),
+            patch("yui.workshop.planner.plan_steps", new_callable=AsyncMock, return_value=steps),
+            patch("yui.workshop.runner.StepExecutor", mock_executor_cls),
+        ):
+            config = _make_config(output_dir=str(tmp_path), max_total_duration_minutes=0)
+            runner = WorkshopTestRunner(config)
+            runner.max_total_duration = 0
+            result = await runner.run_test("https://catalog.workshops.aws/example")
+        timeout_steps = [o for o in result.outcomes if o.result == StepResult.TIMEOUT]
+        assert len(timeout_steps) >= 1
+
+
+class TestCostGuard:
+    @pytest.mark.asyncio
+    async def test_cost_guard_aborts_on_exceed(self, tmp_path):
+        steps = [_make_step()]
+        pages = _make_pages()
+        mock_executor_cls = MagicMock()
+        mock_executor = MagicMock()
+        async def fake_execute(step):
+            return StepOutcome(step=step, result=StepResult.PASS)
+        mock_executor.execute = fake_execute
+        mock_executor_cls.return_value = mock_executor
+        with (
+            patch("yui.workshop.scraper.scrape_workshop", new_callable=AsyncMock, return_value=pages),
+            patch("yui.workshop.planner.plan_steps", new_callable=AsyncMock, return_value=steps),
+            patch("yui.workshop.runner.StepExecutor", mock_executor_cls),
+        ):
+            config = _make_config(output_dir=str(tmp_path))
+            runner = WorkshopTestRunner(config)
+            runner.resource_manager.check_cost_guard = MagicMock(return_value=False)
+            result = await runner.run_test("https://catalog.workshops.aws/example")
+        fail_steps = [o for o in result.outcomes if o.result == StepResult.FAIL]
+        assert len(fail_steps) >= 1
+        assert "cost" in fail_steps[0].error_message.lower()
+
+
+class TestCleanup:
+    @pytest.mark.asyncio
+    async def test_cleanup_called_when_requested(self, tmp_path):
+        pages = _make_pages()
+        with (
+            patch("yui.workshop.scraper.scrape_workshop", new_callable=AsyncMock, return_value=pages),
+            patch("yui.workshop.planner.plan_steps", new_callable=AsyncMock, return_value=[]),
+        ):
+            config = _make_config(output_dir=str(tmp_path), cleanup_after_test=True)
+            runner = WorkshopTestRunner(config)
+            runner.resource_manager.cleanup_resources = MagicMock(
+                return_value={"deleted": [], "failed": [], "skipped": []})
+            await runner.run_test("https://catalog.workshops.aws/example", {"cleanup": True})
+            runner.resource_manager.cleanup_resources.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_cleanup_on_dry_run(self, tmp_path):
+        pages = _make_pages()
+        with (
+            patch("yui.workshop.scraper.scrape_workshop", new_callable=AsyncMock, return_value=pages),
+            patch("yui.workshop.planner.plan_steps", new_callable=AsyncMock, return_value=[]),
+        ):
+            config = _make_config(output_dir=str(tmp_path))
+            runner = WorkshopTestRunner(config)
+            runner.resource_manager.cleanup_resources = MagicMock()
+            await runner.run_test("https://catalog.workshops.aws/example",
+                                  {"dry_run": True, "cleanup": True})
+            runner.resource_manager.cleanup_resources.assert_not_called()
+
+
+class TestListAndShow:
+    def test_list_tests_empty(self, tmp_path):
+        config = _make_config(output_dir=str(tmp_path))
+        runner = WorkshopTestRunner(config)
+        runner.output_dir = str(tmp_path)
+        assert runner.list_tests() == []
+
+    def test_list_tests_with_reports(self, tmp_path):
+        (tmp_path / "report-wt-abc123.md").write_text("# Report")
+        (tmp_path / "report-wt-def456.md").write_text("# Report 2")
+        config = _make_config(output_dir=str(tmp_path))
+        runner = WorkshopTestRunner(config)
+        runner.output_dir = str(tmp_path)
+        tests = runner.list_tests()
+        assert len(tests) == 2
+        test_ids = [t["test_id"] for t in tests]
+        assert "wt-abc123" in test_ids
+        assert "wt-def456" in test_ids
+
+    def test_show_report_found(self, tmp_path):
+        (tmp_path / "report-wt-abc123.md").write_text("# Test Report Content")
+        config = _make_config(output_dir=str(tmp_path))
+        runner = WorkshopTestRunner(config)
+        runner.output_dir = str(tmp_path)
+        content = runner.show_report("wt-abc123")
+        assert content == "# Test Report Content"
+
+    def test_show_report_not_found(self, tmp_path):
+        config = _make_config(output_dir=str(tmp_path))
+        runner = WorkshopTestRunner(config)
+        runner.output_dir = str(tmp_path)
+        content = runner.show_report("wt-nonexistent")
+        assert content is None


### PR DESCRIPTION
## Summary

Workshop Testing Phase C-5, C-6, C-7 implementation.

closes #36
closes #37
closes #38

### New Files
- `src/yui/workshop/reporter.py` — Markdown report + Slack summary (AC-78, AC-79)
- `src/yui/workshop/resource_manager.py` — Tag-based cleanup + cost guard (AC-80, AC-81)
- `src/yui/workshop/runner.py` — Integration orchestrator (AC-82~AC-85)
- 4 test files (75 tests total)

### Modified Files
- `src/yui/cli.py` — `yui workshop test/list-tests/show-report` subcommands
- `src/yui/config.py` — Workshop config section in DEFAULT_CONFIG
- `src/yui/workshop/__init__.py` — Re-exports for new modules

### AC Coverage
| AC | Description | Implementation |
|-----|-------------|----------------|
| AC-78 | Structured test report with video/screenshots | reporter.py generate_report() |
| AC-79 | Slack notification with test summary | reporter.py generate_slack_summary() |
| AC-80 | Tag-based resource cleanup | resource_manager.py cleanup_resources() |
| AC-81 | Cost guard abort | resource_manager.py check_cost_guard() |
| AC-82 | CLI with --record/--cleanup/--headed/--dry-run | cli.py workshop subcommands |
| AC-83 | Per-step and total timeout enforced | runner.py _execute_steps() |
| AC-84 | CLI command fallback | runner.py _execute_single_step() |
| AC-85 | Regression mode (cron) | cli.py --cron flag |

### Tests
- 75 new tests across 4 test files
- Full suite: **549 passed, 14 skipped, 0 failures**

### Notes
- C-3/C-4 modules (console_auth, executor, video_recorder) are imported conditionally via try/except ImportError
- All boto3 calls are mocked in tests (no real AWS operations)