### PR TITLE
fix: fallback system prompt when workspace files missing (#95)

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -37,9 +37,17 @@ class TestSystemPrompt:
         assert "I am Yui" in prompt
 
     def test_missing_both(self, tmp_path):
-        """Both missing → empty string (no crash)."""
+        """Both missing → fallback default prompt (never empty, avoids Bedrock min-length error)."""
+        from yui.agent import _DEFAULT_SYSTEM_PROMPT
+
         prompt = _load_system_prompt(tmp_path)
-        assert prompt == ""
+        assert prompt == _DEFAULT_SYSTEM_PROMPT
+        assert len(prompt) >= 1  # Bedrock requires min length 1
+
+    def test_missing_both_is_not_empty(self, tmp_path):
+        """Bedrock validation guard: system prompt must never be empty string."""
+        prompt = _load_system_prompt(tmp_path)
+        assert prompt.strip() != "", "Empty system prompt causes Bedrock ParamValidationError"
 
 
 class TestCreateAgent:


### PR DESCRIPTION
## 問題

EC2などフレッシュな環境でYuiを起動したとき、~/.yui/workspace/ に AGENTS.md / SOUL.md が存在しないと _load_system_prompt() が空文字列を返す。

Strands AgentがBedrockのConverse APIに system=[{text: ''}] を送信 → ParamValidationError: Invalid length for parameter system[0].text, value: 0, valid min length: 1 でクラッシュ。

結果: Yuiプロセスは起動するが全Slackメンションにタイムアウト（IT-02のみPASS）。

## 修正

- _DEFAULT_SYSTEM_PROMPT 定数を追加
- _load_system_prompt() がpartsが空の場合にfallbackを返すよう修正
- test_missing_both を更新（空文字列 → fallback promptを期待）
- 新テスト test_missing_both_is_not_empty を追加

closes #95