### PR TITLE
fix: system prompt空文字列フォールバック追加 (closes #95)

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -37,9 +37,23 @@ class TestSystemPrompt:
         assert "I am Yui" in prompt
 
     def test_missing_both(self, tmp_path):
-        """Both missing → empty string (no crash)."""
+        """Both missing → falls back to DEFAULT_SYSTEM_PROMPT (no crash, no empty string)."""
+        from yui.agent import DEFAULT_SYSTEM_PROMPT
         prompt = _load_system_prompt(tmp_path)
-        assert prompt == ""
+        assert prompt == DEFAULT_SYSTEM_PROMPT
+
+    def test_load_system_prompt_empty_returns_default(self, tmp_path):
+        """Both AGENTS.md and SOUL.md absent → returns DEFAULT_SYSTEM_PROMPT (Issue #95)."""
+        from yui.agent import DEFAULT_SYSTEM_PROMPT
+        prompt = _load_system_prompt(tmp_path)
+        assert prompt == DEFAULT_SYSTEM_PROMPT
+        assert prompt == "You are Yui, a helpful AI assistant."
+
+    def test_load_system_prompt_empty_not_empty_string(self, tmp_path):
+        """Both files absent → must NOT return empty string (Issue #95 regression guard)."""
+        prompt = _load_system_prompt(tmp_path)
+        assert prompt != ""
+        assert len(prompt) > 0
 
 
 class TestCreateAgent:


### PR DESCRIPTION
## 概要

`_load_system_prompt()` がAGENTS.md/SOUL.md未存在時に空文字列を返し、BedrockのConverse APIが `ParamValidationError` をスローするバグを修正。

## 変更内容

- `DEFAULT_SYSTEM_PROMPT = "You are Yui, a helpful AI assistant."` を追加
- `parts` が空の場合に `DEFAULT_SYSTEM_PROMPT` を返すフォールバック処理を追加
- AGENTS.md未存在時に `logger.warning()` 出力（`logger.info()` から変更）

## テスト

`tests/test_agent.py` に以下を追加：
- `test_load_system_prompt_empty_returns_default` — 両ファイル不在→デフォルト返却
- `test_load_system_prompt_empty_not_empty_string` — 空文字列が返らないことを確認

既存の `test_missing_both` も空文字列アサートから DEFAULT_SYSTEM_PROMPT アサートに更新。

```
5 passed in 1.23s
```

closes #95