### PR TITLE
fix: E2EテストSkip解消 — pytestmark混入削除 + CI Playwright install追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,6 +175,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[dev]'
+          playwright install chromium --with-deps
       
       - name: Run E2E tests
         run: |

--- a/tests/test_agentcore_e2e.py
+++ b/tests/test_agentcore_e2e.py
@@ -403,9 +403,6 @@ import json
 import datetime
 import math
 
-pytestmark = pytest.mark.e2e
-
-
 data = {'test': True, 'timestamp': str(datetime.datetime.now())}
 json_str = json.dumps(data)
 print(f'JSON: {json_str}')


### PR DESCRIPTION
## 変更内容

### 問題
E2Eテストで以下のSkipが発生していた:
- `test_python_imports_standard_library`: コード実行文字列内に `pytestmark = pytest.mark.e2e` が混入 → テスト自体が汚染される
- `test_https_ssl_handling`: Playwright未インストールで `_browser_skip` によりSkip
- `test_url_navigation_content_extraction`: 同上

### 修正
1. **`tests/test_agentcore_e2e.py`**: code_executeに渡すPythonコード文字列内の `pytestmark = pytest.mark.e2e` を削除
2. **`.github/workflows/test.yml`**: E2EジョブのInstall dependenciesに `playwright install chromium --with-deps` を追加

### IAM権限対応（別途実施済み）
- `bedrock-agentcore:StopBrowserSession` を `yui-agent-dev-policy` (v3) に追加済み

### 期待される結果
- 21 passed → 24 passed（Skip 4 → 0）
- 全E2Eテストグリーン

relates #94