### PR TITLE
fix: web_browse returns None when __enter__ raises AccessDeniedException

### DIFF
--- a/src/yui/tools/agentcore.py
+++ b/src/yui/tools/agentcore.py
@@ -105,6 +105,9 @@ def web_browse(url: str, task: str = "extract main content", timeout: int = 30) 
                     logger.warning("Browser session cleanup failed (result already obtained): %s", ctx_e)
                 else:
                     raise
+            else:
+                # No result obtained yet (e.g. __enter__ failed) — propagate to outer handler
+                raise
         if _browse_result is not None:
             return _browse_result
 


### PR DESCRIPTION
## Summary

Fixes #103

## Root Cause

In `web_browse()`, when `browser_session.__enter__` raises an exception (e.g. `AccessDeniedException`):
- `_browse_result` is still `None`
- The inner `except Exception as ctx_e` block only handled the case when `_browse_result is not None`
- When `_browse_result is None`, neither the re-raise nor any return was executed
- The exception was silently swallowed, and the function returned `None`

## Fix

Added `else: raise` branch to propagate the exception when no browse result was obtained yet, allowing the outer `except Exception as e` handler to correctly return the `'Error: No permission...'" error string.

## Test Results

```
tests/test_agentcore.py::test_web_browse_permission_denied PASSED
17/17 passed
```

## Change Size
- 1 file, +3 lines